### PR TITLE
Support ouilookup v0.3.1

### DIFF
--- a/l2fuzz.py
+++ b/l2fuzz.py
@@ -3,7 +3,7 @@ import sys, os, re
 import datetime, json
 
 from scapy.all import *
-from OuiLookup import OuiLookup
+from ouilookup import OuiLookup
 from collections import OrderedDict
 
 from l2cap_fuzzer import *


### PR DESCRIPTION
Update import statement to support most recent ouilookup in pip. This version 0.3.1 was released in May 13, 2023.

According to https://github.com/ndejong/ouilookup/issues/3, to avoid import issue.